### PR TITLE
3DS2 integration fixes

### DIFF
--- a/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/DemoFeatureListActivity.kt
+++ b/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/DemoFeatureListActivity.kt
@@ -375,7 +375,7 @@ class DemoFeatureListActivity : AppCompatActivity() {
             }
 
             return Reference.Builder()
-                .setConsumerReference(UUID.randomUUID().toString())
+                .setConsumerReference("my-unique-ref")
                 .setPaymentReference(paymentReference)
                 .build()
         }

--- a/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/noui/DemoNoUiPaymentActivity.kt
+++ b/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/noui/DemoNoUiPaymentActivity.kt
@@ -44,8 +44,8 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
 
     private lateinit var sharedPreferences: SharedPreferences
     private lateinit var service: JudoApiService
-    private lateinit var cardTransactionService: CardTransactionService
     private lateinit var transactionDetailsBuilder: TransactionDetail.Builder
+    private var cardTransactionService: CardTransactionService? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -77,7 +77,7 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
                 service
             )
             handleState(ActivityState.PayWithCard)
-            cardTransactionService.makeTransaction(
+            cardTransactionService?.makeTransaction(
                 transactionDetailsBuilder
                     .setCardNumber("4000023104662535")
                     .setExpirationDate("12/25")
@@ -85,7 +85,6 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
                     .build(),
                 object : CardTransactionCallback {
                     override fun onFinish(result: JudoPaymentResult) {
-                        handleState(ActivityState.Idle)
                         setResult(result.code, result.toIntent())
                         finish()
                     }
@@ -105,7 +104,7 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
                 service
             )
             handleState(ActivityState.PayWithToken)
-            cardTransactionService.tokenPayment(
+            cardTransactionService?.tokenPayment(
                 transactionDetailsBuilder.build(),
                 object : CardTransactionCallback {
                     override fun onFinish(result: JudoPaymentResult) {
@@ -124,7 +123,7 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
                 service
             )
             handleState(ActivityState.PayWithPreAuthToken)
-            cardTransactionService.tokenPayment(
+            cardTransactionService?.tokenPayment(
                 transactionDetailsBuilder.build(),
                 object : CardTransactionCallback {
                     override fun onFinish(result: JudoPaymentResult) {
@@ -172,7 +171,7 @@ class DemoNoUiPaymentActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
-        cardTransactionService.destroy()
+        cardTransactionService?.destroy()
         super.onDestroy()
     }
 

--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/model/request/SaveCardRequest.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/model/request/SaveCardRequest.kt
@@ -19,7 +19,7 @@ class SaveCardRequest private constructor(
     private var judoId: String,
     private var yourConsumerReference: String,
     private var yourPaymentMetaData: Map<String, String>?,
-    private var cardAddress: Address,
+    private var cardAddress: Address?,
     private var cardNumber: String,
     private var cv2: String,
     private var expiryDate: String,
@@ -90,7 +90,6 @@ class SaveCardRequest private constructor(
             val myExpiryDate = requireNotNullOrEmpty(expiryDate, "expiryDate")
             val paymentReference =
                 requireNotNullOrEmpty(yourPaymentReference, "yourPaymentReference")
-            val myAddress = requireNotNull(address, "address")
 
             return SaveCardRequest(
                 uniqueRequest,
@@ -99,7 +98,7 @@ class SaveCardRequest private constructor(
                 id,
                 consumerReference,
                 yourPaymentMetaData,
-                myAddress,
+                address,
                 myCardNumber,
                 myCv2,
                 myExpiryDate,

--- a/judokit-android/src/main/java/com/judopay/judokit/android/service/CardTransactionService.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/service/CardTransactionService.kt
@@ -146,7 +146,7 @@ class CardTransactionService(
                     "2.1.0"
                 )
                 val address =
-                    if (judo.is3DS2Enabled && !judo.paymentWidgetType.isPaymentMethodsWidget) {
+                    if (judo.is3DS2Enabled && !judo.paymentWidgetType.isPaymentMethodsWidget && judo.paymentWidgetType != PaymentWidgetType.CREATE_CARD_TOKEN) {
                         Address.Builder().apply {
                             setLine1(transactionDetail.addressLine1)
                             setLine2(transactionDetail.addressLine2)
@@ -155,7 +155,7 @@ class CardTransactionService(
                             setPostCode(transactionDetail.postalCode)
                             setCountryCode(transactionDetail.country?.toIntOrNull())
                         }.build()
-                    } else Address.Builder().build()
+                    } else null
 
                 val apiResult = when (judo.paymentWidgetType) {
                     PaymentWidgetType.CARD_PAYMENT -> performPaymentRequest(
@@ -392,20 +392,24 @@ class CardTransactionService(
         .setPhoneCountryCode(inputModel.phoneCountryCode)
         .build()
 
-    private fun buildSaveCardRequest(address: Address?, inputModel: TransactionDetail) =
-        SaveCardRequest.Builder()
+    private fun buildSaveCardRequest(address: Address?, inputModel: TransactionDetail): SaveCardRequest {
+        val request = SaveCardRequest.Builder()
             .setUniqueRequest(false)
             .setYourPaymentReference(judo.reference.paymentReference)
             .setCurrency(judo.amount.currency.name)
             .setJudoId(judo.judoId)
             .setYourConsumerReference(judo.reference.consumerReference)
             .setYourPaymentMetaData(judo.reference.metaData?.toMap())
-            .setAddress(address)
             .setCardNumber(inputModel.cardNumber)
             .setExpiryDate(inputModel.expirationDate)
             .setCv2(inputModel.securityNumber)
             .setPrimaryAccountDetails(judo.primaryAccountDetails)
-            .build()
+
+        if (address != null) {
+            request.setAddress(address)
+        }
+        return request.build()
+    }
 
     private fun buildCheckCardRequest(address: Address?, inputModel: TransactionDetail) =
         CheckCardRequest.Builder()


### PR DESCRIPTION
Removed require not null validation for Address in SaveCardRequest.kt
Fixed a bug in DemoNoUiPaymentActivity.kt, CardTransactionService.kt could be not initialized
Reverted consumerReference
If transaction is 3DS2 and create card token then address can be null