### PR TITLE
Regex Fixes - Billing Details

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/validation/billingdetails/BillingDetailsPostCodeValidator.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/validation/billingdetails/BillingDetailsPostCodeValidator.kt
@@ -10,7 +10,7 @@ class BillingDetailsPostCodeValidator(
     override val fieldType: String = BillingDetailsFieldType.POST_CODE.name
 ) : Validator {
 
-    private val regex = Regex("^[a-zA-Z0-9]+\$")
+    private val regex = Regex("^[a-zA-Z0-9 ]+\$")
 
     override fun validate(input: String, formFieldEvent: FormFieldEvent): ValidationResult {
         val shouldDisplayMessage = formFieldEvent == FormFieldEvent.FOCUS_CHANGED

--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/validation/billingdetails/CityValidator.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/validation/billingdetails/CityValidator.kt
@@ -10,7 +10,7 @@ data class CityValidator(
     override val fieldType: String = BillingDetailsFieldType.CITY.name
 ) : Validator {
 
-    private val regex = Regex("^[A-Za-z]+\$")
+    private val regex = Regex("^[A-Za-z ]+\$")
 
     override fun validate(input: String, formFieldEvent: FormFieldEvent): ValidationResult {
         val shouldDisplayMessage = formFieldEvent == FormFieldEvent.FOCUS_CHANGED


### PR DESCRIPTION
Allow full postcodes to be entered including a space (For UK postcodes) - Ideally this regex should change to be a REGEX based on the input country.

Allow cities to have a space in their name, cities like Milton Keynes are now valid.