### PR TITLE
CT-2723 Android fix of empty CV2 being sent when it's value is missing

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/model/request/Complete3DS2Request.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/model/request/Complete3DS2Request.kt
@@ -2,5 +2,5 @@ package com.judopay.judokit.android.api.model.request
 
 data class Complete3DS2Request(
     private val version: String,
-    private val cv2: String
+    private val cv2: String?
 )

--- a/judokit-android/src/main/java/com/judopay/judokit/android/service/CardTransactionManager.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/service/CardTransactionManager.kt
@@ -256,7 +256,7 @@ class CardTransactionManager private constructor(private var context: FragmentAc
     private fun performComplete3ds2(receipt: Receipt, caller: String) {
         val receiptId = receipt.receiptId ?: ""
         val version = receipt.getCReqParameters()?.messageVersion ?: judo.threeDSTwoMessageVersion
-        val cv2 = transactionDetails?.securityNumber ?: ""
+        val cv2 = transactionDetails?.securityNumber
 
         applicationScope.launch {
             val result =


### PR DESCRIPTION
Summary: Eugene identified two situations, where backend is hit by Android with CV2 being empty string - where actually its value was not present.

The endpoint is: PUT transactions/id/complete3ds

Two situations in the app where the problem occurred: Payment Methods and Token Payments

Diagnosis: I have checked iOS code which works well, and in that code we basically "pass further what we get" in terms of CV2 value. In Android we assign empty string when it's missing, therefore we always send empty CV2 string.

Fix: I have adjusted Android code to be consistent with iOS, and tested myself. Empty CV2 values are not send through anymore. The app builds and opens correctly.

<img width="771" alt="Screenshot 2023-07-26 at 09 28 29" src="https://github.com/Judopay/JudoKit-Android/assets/138582109/112ebb9c-1af4-4471-b506-8b5e9b3368b8">

