### PR TITLE
Fixes problem with Chucker displaying json before interceptors work

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/JudoApiServiceFactory.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/JudoApiServiceFactory.kt
@@ -120,19 +120,20 @@ object JudoApiServiceFactory : ServiceFactory<JudoApiService>() {
             )
 
             setTimeouts(builder, judo.networkTimeout)
-            addInterceptors(builder, context, judo)
+            applyInternalInterceptors(builder, context, judo)
+            applyExternalInterceptors(builder)
             builder.build()
         } catch (e: Exception) {
             throw RuntimeException(e)
         }
     }
 
-    override fun addInterceptors(
+    override fun applyInternalInterceptors(
         client: OkHttpClient.Builder,
         context: Context,
         judo: Judo,
     ) {
-        super.addInterceptors(client, context, judo)
+        super.applyInternalInterceptors(client, context, judo)
         client.interceptors().apply {
             add(
                 ApiHeadersInterceptor(

--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/RecommendationApiServiceFactory.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/RecommendationApiServiceFactory.kt
@@ -42,12 +42,12 @@ object RecommendationApiServiceFactory : ServiceFactory<RecommendationApiService
         ).create(RecommendationApiService::class.java)
     }
 
-    override fun addInterceptors(
+    override fun applyInternalInterceptors(
         client: OkHttpClient.Builder,
         context: Context,
         judo: Judo,
     ) {
-        super.addInterceptors(client, context, judo)
+        super.applyInternalInterceptors(client, context, judo)
         client.interceptors().add(RecommendationHeadersInterceptor(judo.authorization))
     }
 
@@ -57,8 +57,8 @@ object RecommendationApiServiceFactory : ServiceFactory<RecommendationApiService
     ): OkHttpClient {
         val builder = OkHttpClient.Builder()
         setRecommendationCallTimeout(builder, judo)
-        addInterceptors(builder, context, judo)
-
+        applyInternalInterceptors(builder, context, judo)
+        applyExternalInterceptors(builder)
         return builder.build()
     }
 

--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/ServiceFactory.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/factory/ServiceFactory.kt
@@ -48,13 +48,20 @@ abstract class ServiceFactory<T> {
         judo: Judo,
     ): OkHttpClient
 
-    open fun addInterceptors(
+    open fun applyInternalInterceptors(
         client: OkHttpClient.Builder,
         context: Context,
         judo: Judo,
     ) {
         client.interceptors().apply {
             add(NetworkConnectivityInterceptor(context))
+        }
+    }
+
+    protected fun applyExternalInterceptors(
+        client: OkHttpClient.Builder
+    ) {
+        client.interceptors().apply {
             externalInterceptors?.forEach {
                 add(it)
             }


### PR DESCRIPTION
1. Eugene has found problem with our Android SDK demo app Chucker, that displays the json before interceptors are applied.

2. It has been checked with backend to confirm version of JSON they receive (it was as expected, different than displayed in Chucker).

3. I have separated logic for internal and external (Chucker only in our case) interceptors, and ensured that the external ones are called after internal.

4. Tested locally, now Chucker shows correct JSON form.