### PR TITLE
Backward compatibility fixes 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,8 +283,8 @@ jobs:
               --client-details=matrixLabel="Backward Compat E2E (API 31)" \
               --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
-      # - notify_slack_error_weekly
-      # - notify_slack_pass_weekly
+      - notify_slack_error_weekly
+      - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_32:
     <<: *android-docker-executor
     steps:
@@ -303,8 +303,8 @@ jobs:
               --client-details=matrixLabel="Backward Compat E2E (API 32)" \
               --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
-      # - notify_slack_error_weekly
-      # - notify_slack_pass_weekly
+      - notify_slack_error_weekly
+      - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_33:
     <<: *android-docker-executor
     steps:
@@ -323,8 +323,8 @@ jobs:
               --client-details=matrixLabel="Backward Compat E2E (API 33)" \
               --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
-      # - notify_slack_error_weekly
-      # - notify_slack_pass_weekly
+      - notify_slack_error_weekly
+      - notify_slack_pass_weekly
 
   sonar_scan:
     docker:
@@ -425,16 +425,16 @@ workflows:
           filters:
             branches:
               only:
-                - backward-compat-fixes
+                - master
       - instrumented_test_sample_weekly_api_32:
           context: shared-secrets
           filters:
             branches:
               only:
-                - backward-compat-fixes
+                - master
       - instrumented_test_sample_weekly_api_33:
           context: shared-secrets
           filters:
             branches:
               only:
-                - backward-compat-fixes
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,7 @@ jobs:
               --device model=a51,version=31 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 31)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
@@ -301,7 +301,7 @@ jobs:
               --device model=bluejay,version=32 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 32)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
@@ -321,7 +321,7 @@ jobs:
               --device model=panther,version=33 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 33)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest" \
               --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,7 +280,8 @@ jobs:
               --timeout=30m \
               --device model=a51,version=31 \
               --use-orchestrator \
-              --client-details=matrixLabel="Backward Compat E2E (API 31)"
+              --client-details=matrixLabel="Backward Compat E2E (API 31)" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_32:
@@ -298,7 +299,8 @@ jobs:
               --timeout=30m \
               --device model=bluejay,version=32 \
               --use-orchestrator \
-              --client-details=matrixLabel="Backward Compat E2E (API 32)"
+              --client-details=matrixLabel="Backward Compat E2E (API 32)" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_33:
@@ -316,7 +318,8 @@ jobs:
               --timeout=30m \
               --device model=panther,version=33 \
               --use-orchestrator \
-              --client-details=matrixLabel="Backward Compat E2E (API 33)"
+              --client-details=matrixLabel="Backward Compat E2E (API 33)" \
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,7 +265,43 @@ jobs:
       - notify_slack_pass
 
 
-  instrumented_test_sample_weekly:
+  instrumented_test_sample_weekly_api_31:
+    <<: *android-docker-executor
+    steps:
+      - prepare_instrumented_tests
+      - run:
+          name: Test with Firebase Test Lab
+          no_output_timeout: 30m
+          command: >
+            gcloud firebase test android run \
+              --app judokit-android-examples/build/outputs/apk/debug/judokit-android-examples-debug.apk \
+              --test judokit-android-examples/build/outputs/apk/androidTest/debug/judokit-android-examples-debug-androidTest.apk \
+              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+              --timeout=30m \
+              --device model=a51,version=31 \
+              --use-orchestrator \
+              --client-details=matrixLabel="Backward Compat E2E (API 31)"
+      # - notify_slack_error_weekly
+      # - notify_slack_pass_weekly
+  instrumented_test_sample_weekly_api_32:
+    <<: *android-docker-executor
+    steps:
+      - prepare_instrumented_tests
+      - run:
+          name: Test with Firebase Test Lab
+          no_output_timeout: 30m
+          command: >
+            gcloud firebase test android run \
+              --app judokit-android-examples/build/outputs/apk/debug/judokit-android-examples-debug.apk \
+              --test judokit-android-examples/build/outputs/apk/androidTest/debug/judokit-android-examples-debug-androidTest.apk \
+              --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
+              --timeout=30m \
+              --device model=bluejay,version=32 \
+              --use-orchestrator \
+              --client-details=matrixLabel="Backward Compat E2E (API 32)"
+      # - notify_slack_error_weekly
+      # - notify_slack_pass_weekly
+  instrumented_test_sample_weekly_api_33:
     <<: *android-docker-executor
     steps:
       - prepare_instrumented_tests
@@ -279,12 +315,10 @@ jobs:
               --results-bucket $FIREBASE_TEST_RESULTS_BUCKET \
               --timeout=30m \
               --device model=panther,version=33 \
-              --device model=bluejay,version=32 \
-              --device model=a51,version=31 \
               --use-orchestrator \
-              --client-details=matrixLabel="Backward Compat E2E"
-      - notify_slack_error_weekly
-      - notify_slack_pass_weekly
+              --client-details=matrixLabel="Backward Compat E2E (API 33)"
+      # - notify_slack_error_weekly
+      # - notify_slack_pass_weekly
 
   sonar_scan:
     docker:
@@ -380,9 +414,21 @@ workflows:
   e2e-backward-compat-weekly:
     when: << pipeline.parameters.weekly >>
     jobs:
-      - instrumented_test_sample_weekly:
+      - instrumented_test_sample_weekly_api_31:
           context: shared-secrets
           filters:
             branches:
               only:
-                - master
+                - backward-compat-fixes
+      - instrumented_test_sample_weekly_api_32:
+          context: shared-secrets
+          filters:
+            branches:
+              only:
+                - backward-compat-fixes
+      - instrumented_test_sample_weekly_api_33:
+          context: shared-secrets
+          filters:
+            branches:
+              only:
+                - backward-compat-fixes

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,7 +281,8 @@ jobs:
               --device model=a51,version=31 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 31)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_32:
@@ -300,7 +301,8 @@ jobs:
               --device model=bluejay,version=32 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 32)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
   instrumented_test_sample_weekly_api_33:
@@ -319,7 +321,8 @@ jobs:
               --device model=panther,version=33 \
               --use-orchestrator \
               --client-details=matrixLabel="Backward Compat E2E (API 33)" \
-              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest"
+              --test-targets="class com.judokit.android.examples.test.card.CardPaymentTest, class com.judokit.android.examples.test.card.IdealTest" \
+              --num-flaky-test-attempts=1
       # - notify_slack_error_weekly
       # - notify_slack_pass_weekly
 

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/CardPaymentTest.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/CardPaymentTest.kt
@@ -257,6 +257,7 @@ class CardPaymentTest {
             .perform(click())
 
         awaitActivityThenRun("com.judopay.judo3ds2.ui.challenge.ChallengeActivity") {
+            Thread.sleep(5000)
             onView(withText("CANCEL"))
                 .perform(click())
         }

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/Functions.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/Functions.kt
@@ -68,7 +68,7 @@ fun <IR : IdlingResource> awaitIdlingResourceThenRun(
  */
 fun clickCompleteOn3DS2Screen() {
     assertOnView(withText("COMPLETE"))
-    Thread.sleep(20000)
+    Thread.sleep(30000)
     onView(withText("COMPLETE"))
         .perform(ViewActions.longClick())
 }

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/Functions.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/Functions.kt
@@ -159,7 +159,7 @@ fun updateRecommendationUrlWith(suffix: String) {
     onView(withText("Generate payment session"))
         .perform(click())
 
-    Thread.sleep(10000)
+    Thread.sleep(20000)
 }
 
 fun fillBillingDetails(

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/IdealTest.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/IdealTest.kt
@@ -67,7 +67,7 @@ class IdealTest {
         onView(withId(R.id.payButton))
             .perform(click())
 
-        Thread.sleep(3000)
+        Thread.sleep(10000)
 
         onView(withId(R.id.idealWebView)).perform(swipeUp())
         clickButtonOnWebViewWithText(Ideal.NEXT_BUTTON)


### PR DESCRIPTION
* Only run against card payment tests
* More provisions for 3DS2 screen
* Split the 3 devices/OS versions into separate test suites so they can retry independently 