### PR TITLE
CT-3062: Missing 'pan only' authorisation method aded to Google Pay configuration

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/common/Mappers.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/common/Mappers.kt
@@ -28,13 +28,15 @@ import com.judopay.judokit.android.toMap
 
 internal fun GooglePayConfiguration.toGooglePayPaymentMethod(judo: Judo): GooglePayPaymentMethod {
     val networks = judo.supportedCardNetworks.filter { it.isSupportedByGooglePay }
+    val allowedAuthMethods =
+        arrayOf(
+            GooglePayAuthMethod.PAN_ONLY,
+            GooglePayAuthMethod.CRYPTOGRAM_3DS,
+        )
 
     val cardParameters =
         GooglePayCardParameters(
-            allowedAuthMethods =
-                arrayOf(
-                    GooglePayAuthMethod.CRYPTOGRAM_3DS,
-                ),
+            allowedAuthMethods = allowedAuthMethods,
             allowedCardNetworks = networks.toTypedArray(),
             allowPrepaidCards = allowPrepaidCards,
             allowCreditCards = allowCreditCards,


### PR DESCRIPTION
<img width="699" alt="Screenshot 2025-04-11 at 17 42 01" src="https://github.com/user-attachments/assets/41206c55-d3a1-4715-9cdf-2eef2c527497" />

Source: 
developers.google.com
https://developers.google.com/pay/api/web/guides/resources/update-to-latest-version#apiversion-2

Testing:
![490975299_10093232304021668_6372366637082021233_n](https://github.com/user-attachments/assets/75b674b2-a682-41a1-b333-c5150c56ec4c)


