### PR TITLE
Address flaky tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,8 +258,8 @@ jobs:
               --use-orchestrator \
               --client-details=matrixLabel="Regression E2E" \
               --num-flaky-test-attempts=1
-      # - notify_slack_error
-      # - notify_slack_pass
+      - notify_slack_error
+      - notify_slack_pass
 
 
   instrumented_test_sample_weekly_api_31:
@@ -388,7 +388,7 @@ workflows:
           filters:
             branches:
               only:
-                - fix-flaky-tests
+                - master
 
   publish_sdk:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -258,8 +258,8 @@ jobs:
               --use-orchestrator \
               --client-details=matrixLabel="Regression E2E" \
               --num-flaky-test-attempts=1
-      - notify_slack_error
-      - notify_slack_pass
+      # - notify_slack_error
+      # - notify_slack_pass
 
 
   instrumented_test_sample_weekly_api_31:
@@ -388,7 +388,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - fix-flaky-tests
 
   publish_sdk:
     jobs:

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/RavelinIntegrationTest.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/RavelinIntegrationTest.kt
@@ -71,6 +71,7 @@ class RavelinIntegrationTest {
                 putBoolean("is_recommendation_feature_enabled", true)
                 putString("rsa_key", BuildConfig.RSA_KEY)
                 putStringSet("payment_methods", setOf("CARD"))
+                putBoolean("is_address_enabled", false)
             }
             .commit()
     }


### PR DESCRIPTION
Sometimes the Chucker screen (which don't have much control over) has the 3DS2 assertions we need towards the bottom of the request, so toggling card address off will save on the amount of text shown and this info is in view more often than not