### PR TITLE
CT-3059 Accessibility: headings & labels

### DIFF
--- a/judokit-android/api/judokit-android.api
+++ b/judokit-android/api/judokit-android.api
@@ -1268,9 +1268,9 @@ public final class com/judopay/judokit/android/databinding/BillingDetailsFormVie
 	public final field billingDetailsBackButton Lcom/judopay/judokit/android/ui/common/ProgressButton;
 	public final field billingDetailsBottomAppBar Lcom/google/android/material/bottomappbar/BottomAppBar;
 	public final field billingDetailsContainerLayout Landroidx/constraintlayout/widget/ConstraintLayout;
+	public final field billingDetailsHeading Landroid/widget/TextView;
 	public final field billingDetailsScrollView Landroidx/core/widget/NestedScrollView;
 	public final field billingDetailsSubmitButton Lcom/judopay/judokit/android/ui/common/ProgressButton;
-	public final field billingDetailsTextView Landroid/widget/TextView;
 	public final field cityTextInputEditText Landroid/widget/EditText;
 	public final field cityTextInputLayout Lcom/judopay/judokit/android/ui/cardentry/components/JudoEditTextInputLayout;
 	public final field countryTextInputEditText Landroid/widget/AutoCompleteTextView;
@@ -1313,6 +1313,7 @@ public final class com/judopay/judokit/android/databinding/CardEntryFormViewBind
 	public final field cardContainer Landroidx/coordinatorlayout/widget/CoordinatorLayout;
 	public final field cardDetailsContainerLayout Landroidx/constraintlayout/widget/ConstraintLayout;
 	public final field cardEntryBottomAppBar Lcom/google/android/material/bottomappbar/BottomAppBar;
+	public final field cardEntryHeading Landroid/widget/TextView;
 	public final field cardEntrySubmitButton Lcom/judopay/judokit/android/ui/common/ProgressButton;
 	public final field countryTextInputEditText Landroid/widget/AutoCompleteTextView;
 	public final field countryTextInputLayout Lcom/judopay/judokit/android/ui/cardentry/components/JudoEditTextInputLayout;

--- a/judokit-android/api/judokit-android.api
+++ b/judokit-android/api/judokit-android.api
@@ -1382,6 +1382,7 @@ public final class com/judopay/judokit/android/databinding/EditCardFragmentBindi
 	public final field saveButton Lcom/google/android/material/button/MaterialButton;
 	public final field titleEditText Landroid/widget/EditText;
 	public final field titleTextInputLayout Lcom/judopay/judokit/android/ui/cardentry/components/JudoEditTextInputLayout;
+	public final field toolbar Landroid/widget/LinearLayout;
 	public static fun bind (Landroid/view/View;)Lcom/judopay/judokit/android/databinding/EditCardFragmentBinding;
 	public synthetic fun getRoot ()Landroid/view/View;
 	public fun getRoot ()Landroidx/constraintlayout/widget/ConstraintLayout;

--- a/judokit-android/src/main/res/layout/billing_details_form_view.xml
+++ b/judokit-android/src/main/res/layout/billing_details_form_view.xml
@@ -29,7 +29,7 @@
                 android:id="@+id/flow1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="billingDetailsTextView,emailTextInputLayout,countryTextInputLayout,administrativeDivisionTextInputLayout,flow2,addressLine1TextInputLayout,addressLine2TextInputLayout,addressLine3TextInputLayout,addAddressLineButton,cityTextInputLayout,postalCodeTextInputLayout"
+                app:constraint_referenced_ids="billingDetailsHeading,emailTextInputLayout,countryTextInputLayout,administrativeDivisionTextInputLayout,flow2,addressLine1TextInputLayout,addressLine2TextInputLayout,addressLine3TextInputLayout,addAddressLineButton,cityTextInputLayout,postalCodeTextInputLayout"
                 app:flow_horizontalAlign="start"
                 app:flow_horizontalBias="0"
                 app:flow_maxElementsWrap="1"
@@ -41,7 +41,7 @@
                 app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
-                android:id="@+id/billingDetailsTextView"
+                android:id="@+id/billingDetailsHeading"
                 style="@style/JudoTheme.TextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/judokit-android/src/main/res/layout/billing_details_form_view.xml
+++ b/judokit-android/src/main/res/layout/billing_details_form_view.xml
@@ -42,12 +42,10 @@
 
             <TextView
                 android:id="@+id/billingDetailsHeading"
-                style="@style/JudoTheme.TextView"
+                style="@style/JudoTheme.Title.Dark"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/jp_billing_details_title"
-                android:textColor="@color/jpDarkGrayColor"
-                android:textSize="@dimen/text_size_18" />
+                android:text="@string/jp_billing_details_title" />
 
             <com.judopay.judokit.android.ui.cardentry.components.JudoEditTextInputLayout
                 android:id="@+id/emailTextInputLayout"

--- a/judokit-android/src/main/res/layout/card_entry_form_view.xml
+++ b/judokit-android/src/main/res/layout/card_entry_form_view.xml
@@ -40,12 +40,10 @@
 
             <TextView
                 android:id="@+id/cardEntryHeading"
-                style="@style/JudoTheme.TextView"
+                style="@style/JudoTheme.Title.Dark"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/jp_card_entry_title"
-                android:textColor="@color/jpDarkGrayColor"
-                android:textSize="@dimen/text_size_18" />
+                android:text="@string/jp_card_entry_title" />
 
             <com.judopay.judokit.android.ui.cardentry.components.JudoEditTextInputLayout
                 android:id="@+id/numberTextInputLayout"

--- a/judokit-android/src/main/res/layout/card_entry_form_view.xml
+++ b/judokit-android/src/main/res/layout/card_entry_form_view.xml
@@ -27,7 +27,7 @@
                 android:id="@+id/flow1"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                app:constraint_referenced_ids="numberTextInputLayout,nameTextInputLayout"
+                app:constraint_referenced_ids="cardEntryHeading,numberTextInputLayout,nameTextInputLayout"
                 app:flow_horizontalAlign="start"
                 app:flow_horizontalBias="0"
                 app:flow_maxElementsWrap="1"
@@ -37,6 +37,15 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/cardEntryHeading"
+                style="@style/JudoTheme.TextView"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/jp_card_entry_title"
+                android:textColor="@color/jpDarkGrayColor"
+                android:textSize="@dimen/text_size_18" />
 
             <com.judopay.judokit.android.ui.cardentry.components.JudoEditTextInputLayout
                 android:id="@+id/numberTextInputLayout"

--- a/judokit-android/src/main/res/layout/edit_card_fragment.xml
+++ b/judokit-android/src/main/res/layout/edit_card_fragment.xml
@@ -7,25 +7,30 @@
     android:background="@color/white"
     android:fitsSystemWindows="true">
 
-    <ImageButton
-        android:id="@+id/backButton"
-        style="@style/JudoTheme.BackButton"
-        android:contentDescription="@null"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <TextView
-        android:id="@+id/headingTextView"
-        style="@style/JudoTheme.Title.Large"
+    <LinearLayout
+        android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/space_24"
-        android:layout_marginTop="@dimen/space_8"
-        android:layout_marginEnd="@dimen/space_24"
-        android:text="@string/jp_customise_card"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:orientation="horizontal"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/backButton" />
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <ImageButton
+            android:id="@+id/backButton"
+            style="@style/JudoTheme.BackButton"
+            android:contentDescription="@null" />
+
+        <TextView
+            android:id="@+id/headingTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            style="@style/JudoTheme.Title.Large"
+            android:layout_marginStart="@dimen/space_12"
+            android:layout_gravity="center_vertical"
+            android:text="@string/jp_customise_card" />
+
+    </LinearLayout>
 
     <androidx.core.widget.NestedScrollView
         android:layout_width="match_parent"
@@ -34,13 +39,14 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/headingTextView">
+        app:layout_constraintTop_toBottomOf="@+id/toolbar">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:clipToPadding="false"
-            android:padding="@dimen/space_24">
+            android:paddingHorizontal="@dimen/space_24"
+            android:paddingVertical="@dimen/space_18">
 
             <com.judopay.judokit.android.ui.paymentmethods.components.PaymentCardView
                 android:id="@+id/cardView"

--- a/judokit-android/src/main/res/layout/payment_methods_fragment.xml
+++ b/judokit-android/src/main/res/layout/payment_methods_fragment.xml
@@ -28,7 +28,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@drawable/light_pink_gradient_background"
-                android:layout_marginTop="@dimen/space_56"
+                android:layout_marginTop="@dimen/space_74"
                 app:layout_collapseMode="pin">
 
                 <com.judopay.judokit.android.ui.paymentmethods.components.PaymentMethodsHeaderView
@@ -38,12 +38,26 @@
 
             </com.judopay.judokit.android.ui.paymentmethods.components.AppBarLayoutHeightAwareContainerView>
 
-            <!-- TODO: Should be replaced by Toolbar:app:navigationIcon -->
-            <ImageButton
-                android:id="@+id/backButton"
-                style="@style/JudoTheme.BackButton"
-                android:contentDescription="@null"
-                app:layout_collapseMode="pin" />
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                app:layout_collapseMode="pin">
+
+                <ImageButton
+                    android:id="@+id/backButton"
+                    style="@style/JudoTheme.BackButton"
+                    android:contentDescription="@null" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    style="@style/JudoTheme.Title.Large"
+                    android:layout_marginStart="@dimen/space_12"
+                    android:layout_gravity="center_vertical"
+                    android:text="@string/jp_payment_methods_title" />
+
+            </LinearLayout>
 
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>

--- a/judokit-android/src/main/res/values-es/strings.xml
+++ b/judokit-android/src/main/res/values-es/strings.xml
@@ -44,6 +44,7 @@
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
     <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
+    <string name="jp_payment_methods_title">Payment Methods</string>
     <string name="jp_back">Back</string>
 
     <string name="jp_error_mastercard_not_supported">Mastercard no es compatible</string>

--- a/judokit-android/src/main/res/values-es/strings.xml
+++ b/judokit-android/src/main/res/values-es/strings.xml
@@ -42,6 +42,7 @@
     <string name="jp_invalid_city">Please enter a valid city</string>
     <string name="jp_continue_text">Continue</string>
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
+    <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
     <string name="jp_back">Back</string>
 

--- a/judokit-android/src/main/res/values-fr/strings.xml
+++ b/judokit-android/src/main/res/values-fr/strings.xml
@@ -44,6 +44,7 @@
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
     <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
+    <string name="jp_payment_methods_title">Payment Methods</string>
     <string name="jp_back">Back</string>
 
     <string name="jp_error_mastercard_not_supported">Mastercard n\'est pas prise en charge</string>

--- a/judokit-android/src/main/res/values-fr/strings.xml
+++ b/judokit-android/src/main/res/values-fr/strings.xml
@@ -42,6 +42,7 @@
     <string name="jp_invalid_city">Please enter a valid city</string>
     <string name="jp_continue_text">Continue</string>
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
+    <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
     <string name="jp_back">Back</string>
 

--- a/judokit-android/src/main/res/values/dimens.xml
+++ b/judokit-android/src/main/res/values/dimens.xml
@@ -14,6 +14,7 @@
     <dimen name="space_12">12dp</dimen>
     <dimen name="space_10">10dp</dimen>
     <dimen name="space_14">14dp</dimen>
+    <dimen name="space_18">18dp</dimen>
     <dimen name="space_20">20dp</dimen>
     <dimen name="space_24">24dp</dimen>
     <dimen name="space_32">32dp</dimen>

--- a/judokit-android/src/main/res/values/strings.xml
+++ b/judokit-android/src/main/res/values/strings.xml
@@ -134,6 +134,7 @@
 
     <string name="jp_continue_text">Continue</string>
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
+    <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
     <string name="jp_back">Back</string>
     <string name="jp_card_number_entry_field" translatable="false">cardNumberInputField</string>

--- a/judokit-android/src/main/res/values/strings.xml
+++ b/judokit-android/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@
     <string name="jp_add_address_line">Add address line %1$d (optional)</string>
     <string name="jp_card_entry_title">Card Information</string>
     <string name="jp_billing_details_title">Billing Details</string>
+    <string name="jp_payment_methods_title">Payment Methods</string>
     <string name="jp_back">Back</string>
     <string name="jp_card_number_entry_field" translatable="false">cardNumberInputField</string>
     <string name="jp_cardholder_name_entry_field" translatable="false">cardHolderNameField</string>

--- a/judokit-android/src/main/res/values/styles.xml
+++ b/judokit-android/src/main/res/values/styles.xml
@@ -133,6 +133,10 @@
         <item name="android:textSize">@dimen/title</item>
     </style>
 
+    <style name="JudoTheme.Title.Dark" parent="JudoTheme.Title">
+        <item name="android:textColor">@color/jpDarkGrayColor</item>
+    </style>
+
     <style name="JudoTheme.Title.Light" parent="JudoTheme.Title">
         <item name="android:textColor">@color/jpWhiteColor</item>
         <item name="android:maxLines">1</item>


### PR DESCRIPTION
1. Adds Card Information heading:
<img width="325" height="325" alt="Screenshot 2025-08-12 at 12 07 53" src="https://github.com/user-attachments/assets/15535c04-10de-47c9-a57f-b43a58474942" />


2. Adds Paym. Methods heading:
<img width="352" height="423" alt="Screenshot 2025-08-19 at 23 35 03" src="https://github.com/user-attachments/assets/ced567bf-a9a2-4352-a8f5-3b80a9a360a6" />


3. Unifies toolbar/ heading of Paym. Methods and EditCard (for seamless between-screen switching experience):

Before:
[demo.webm](https://github.com/user-attachments/assets/43abb2df-5427-4cee-8bfe-45a6e0c64009)

After:
[demo.webm](https://github.com/user-attachments/assets/4d836914-0e7c-4bf5-9189-1c2c58067177)
