### PR TITLE
Card Validation Fix

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/model/CardNetwork.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/model/CardNetwork.kt
@@ -237,7 +237,7 @@ val CardNetwork.notSupportedErrorMessageResId: Int
             CardNetwork.CHINA_UNION_PAY -> R.string.jp_error_union_pay_not_supported
             CardNetwork.JCB -> R.string.jp_error_jcb_not_supported
             CardNetwork.DINERS_CLUB -> R.string.jp_error_diners_club_not_supported
-            else -> R.string.jp_empty
+            else -> R.string.jp_check_card_number
         }
 
 /**

--- a/judokit-android/src/test/java/com/judopay/judokit/android/model/CardNetworkTest.kt
+++ b/judokit-android/src/test/java/com/judopay/judokit/android/model/CardNetworkTest.kt
@@ -495,10 +495,12 @@ internal class CardNetworkTest {
         )
     }
 
-    @DisplayName("Given notSupportedErrorMessageResId is called, when card network is OTHER, return empty string resource")
+    @DisplayName(
+        "Given notSupportedErrorMessageResId is called, when card network is OTHER, return Invalid card number error string resource",
+    )
     @Test
     fun returnEmptyStringResourceWhenOther() {
-        assertEquals(R.string.jp_empty, CardNetwork.OTHER.notSupportedErrorMessageResId)
+        assertEquals(R.string.jp_check_card_number, CardNetwork.OTHER.notSupportedErrorMessageResId)
     }
 
     @DisplayName("Given defaultCardNameResId is called, when card network is AMEX, return AmEx error string resource")


### PR DESCRIPTION
The problem was selection of error message (notSupportedErrorMessageResId).

<img width="786" height="440" alt="Screenshot 2025-11-11 at 13 36 00" src="https://github.com/user-attachments/assets/d912c1cf-aa76-4833-b9eb-629530aa2120" />

The 1 or 2 digits input falls into case "!isSupported", but later, because the card network is not recognised, it picks up empty string as the error message.

<img width="678" height="312" alt="Screenshot 2025-11-11 at 13 37 04" src="https://github.com/user-attachments/assets/7675f7ae-4391-464a-8799-fe2dd2097ed7" />

As we know that "!isSupported" case always means error (according to my understanding; when the input is not empty), so I have replaced empty string with "Invalid card", and tested. Video attached.

It is now consistent with iOS behaviour.

[demo.webm](https://github.com/user-attachments/assets/a2791986-e530-45e2-ae21-bf70e232dcc4)
