### PR TITLE
PM & CC titles misalignment with the arrow (on big font)

### DIFF
--- a/judokit-android/src/main/res/values/styles.xml
+++ b/judokit-android/src/main/res/values/styles.xml
@@ -25,7 +25,9 @@
         <item name="android:layout_width">@dimen/min_touch_target_size</item>
         <item name="android:layout_height">@dimen/min_touch_target_size</item>
         <item name="android:layout_marginStart">@dimen/space_8</item>
-        <item name="android:layout_marginTop">@dimen/space_4</item>
+        <item name="android:layout_marginTop">@dimen/space_2</item>
+        <item name="android:layout_marginBottom">@dimen/space_2</item>
+        <item name="android:layout_gravity">center_vertical</item>
         <item name="srcCompat">@drawable/ic_back_20dp</item>
     </style>
 


### PR DESCRIPTION
Before:
<img width="293" height="42" alt="Screenshot 2025-11-11 at 09 01 35" src="https://github.com/user-attachments/assets/180b957a-291c-44fb-9d21-3335f411c221" />

After:
<img width="321" height="89" alt="Screenshot 2025-11-18 at 17 54 09" src="https://github.com/user-attachments/assets/53f39335-12a8-42c9-a14d-97857b2b0c0a" />

Affected screens: Payment Methods & Customise Card

Tested on: Pixel9, Samsung S22, normal font, and big font