### PR TITLE
CT-3245 Fixes AVS postcode not being initially auto-validated

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/CardEntryViewModel.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/CardEntryViewModel.kt
@@ -139,6 +139,9 @@ class CardEntryViewModel
             // Initialize the card AVS country so PostcodeValidator uses the right regex from the start.
             cardDetailsFormValidator.country = cardDetailsModel.country.asAVSCountry() ?: AVSCountry.OTHER
 
+            // AVS country is always valid (user chooses among pre-selected values).
+            cardFieldValidity[CardDetailsFieldType.COUNTRY] = true
+
             // Initialize the billing country so country-aware validators are ready.
             val initialBillingCountry = Country.list(context).firstOrNull { it.numericCode == billingAddressModel.countryCode }
             billingDetailsFormValidator.country = initialBillingCountry


### PR DESCRIPTION
The problem was caused by lack of 'Country' record in validation map (cardFieldValidity).

The default value was assigned, but it has never been validated, so the button didn't get active.

I think the simplest fix is to declare the AVS country as 'always valid', as its possible values come from the SDK.

It would be consistent with Billing Address fields like Address Line 2, Address Line 3 we treat exactly in the same way.

Testing Demo:
[Uploading Demo.webm…]()
