### PR TITLE
CT-3246 Fixes isExpiredInTwoMonths logic

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/api/model/response/CardDate.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/api/model/response/CardDate.kt
@@ -73,7 +73,9 @@ class CardDate(
             maxDate[Calendar.MONTH] = maxDate[Calendar.MONTH] + 2
 
             val cardDate = Calendar.getInstance()
-            cardDate[year, month] = 2
+            cardDate[Calendar.YEAR] = year
+            cardDate[Calendar.MONTH] = month - 1
+            cardDate[Calendar.DAY_OF_MONTH] = cardDate.getActualMaximum(Calendar.DAY_OF_MONTH)
 
             val now =
                 Calendar.getInstance().apply {


### PR DESCRIPTION
The logic of assigning card date was incorrect.
1. We incorrectly used to set month. Months in cards are numbered 1-12, but in calendar 0-11, so therefore we should assign "month - 1".
2. We incorrectly used to set 2nd day of month for card date, instead of the last one.

I have tested it with all possible cases (card going to expire this month, next month, in 2 months, and in 3 months).

Testing video:
[demo.webm](https://github.com/user-attachments/assets/21930eae-43ba-457e-a3b0-c3c2ea464ca1)
