### PR TITLE
Fixes hidden AVS countries

### DIFF
--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/components/CardEntryFormView.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/components/CardEntryFormView.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.AutoCompleteTextView
 import android.widget.EditText
+import android.widget.Filter
 import android.widget.FrameLayout
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.widget.NestedScrollView
@@ -70,7 +71,16 @@ class CardEntryFormView
 
         private val countriesAdapter: ArrayAdapter<String> by lazy {
             val countries = AVSCountry.entries.map { context.getString(it.translatableName) }
-            ArrayAdapter(context, android.R.layout.simple_list_item_1, countries)
+            // We need this as AutoCompleteTextView filters the dropdown by input text, so pre-filled UK hides the other AVS countries.
+            object : ArrayAdapter<String>(context, android.R.layout.simple_list_item_1, countries) {
+                override fun getFilter() =
+                    object : Filter() {
+                        override fun performFiltering(c: CharSequence?) =
+                            FilterResults().apply { values = countries; count = countries.size }
+
+                        override fun publishResults(c: CharSequence?, r: FilterResults?) = notifyDataSetChanged()
+                    }
+            }
         }
 
         private val securityCodeFormatter: SecurityCodeInputMaskTextWatcher by lazy {

--- a/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/components/CardEntryFormView.kt
+++ b/judokit-android/src/main/java/com/judopay/judokit/android/ui/cardentry/components/CardEntryFormView.kt
@@ -76,9 +76,15 @@ class CardEntryFormView
                 override fun getFilter() =
                     object : Filter() {
                         override fun performFiltering(c: CharSequence?) =
-                            FilterResults().apply { values = countries; count = countries.size }
+                            FilterResults().apply {
+                                values = countries
+                                count = countries.size
+                            }
 
-                        override fun publishResults(c: CharSequence?, r: FilterResults?) = notifyDataSetChanged()
+                        override fun publishResults(
+                            c: CharSequence?,
+                            r: FilterResults?,
+                        ) = notifyDataSetChanged()
                     }
             }
         }


### PR DESCRIPTION
Reason:
The AVS country dropdown only showed UK because AutoCompleteTextView filters options by the text already in the field, (and UK is pre-filled by default).

Fix:
Overriding the filter in ArrayAdapter fixes the problem, brings back original list.

Alternatives:
I have investigated other ways to fix it, like providing default value ('UK') in other way, but this filter fix seems the least invasive.

Screenshot (testing):
<img width="1080" height="2424" alt="Screenshot_1780563664" src="https://github.com/user-attachments/assets/1b3d5df0-1a79-4ee0-b96a-29b8c69a94f4" />


