### PR TITLE
CT-3243 | Settings Keys naming adjustments

### DIFF
--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/CardPaymentTest.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/CardPaymentTest.kt
@@ -110,14 +110,14 @@ class CardPaymentTest {
             .edit()
             .apply {
                 putString("judo_id", BuildConfig.JUDO_ID)
-                putString("challengeRequestIndicator", "CHALLENGE_AS_MANDATE")
+                putString("challenge_request_indicator", "CHALLENGE_AS_MANDATE")
                 putBoolean("is_payment_session_enabled", false)
                 putString("token", BuildConfig.API_TEST_TOKEN)
                 putString("secret", BuildConfig.API_TEST_SECRET)
                 putString("amount", "0.15")
                 putString("currency", "GBP")
                 putBoolean("should_ask_for_csc", false)
-                putBoolean("is_recommendation_feature_enabled", false)
+                putBoolean("is_recommendation_enabled", false)
             }.commit()
     }
 
@@ -391,7 +391,7 @@ class CardPaymentTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", CHALLENGE_NO_PREFERENCE)
+                putString("challenge_request_indicator", CHALLENGE_NO_PREFERENCE)
             }.commit()
 
         onView(withText(PAY_WITH_CARD_LABEL))
@@ -417,7 +417,7 @@ class CardPaymentTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", CHALLENGE_NO_PREFERENCE)
+                putString("challenge_request_indicator", CHALLENGE_NO_PREFERENCE)
             }.commit()
 
         onView(withText(PAY_WITH_CARD_LABEL))
@@ -443,7 +443,7 @@ class CardPaymentTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", CHALLENGE_NO_PREFERENCE)
+                putString("challenge_request_indicator", CHALLENGE_NO_PREFERENCE)
             }.commit()
 
         onView(withText(PAY_WITH_CARD_LABEL))
@@ -851,8 +851,8 @@ class CardPaymentTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", CHALLENGE_NO_PREFERENCE)
-                putString("scaExemption", SCA_LOW_VALUE)
+                putString("challenge_request_indicator", CHALLENGE_NO_PREFERENCE)
+                putString("sca_exemption", SCA_LOW_VALUE)
             }.commit()
         onView(withText(PAY_WITH_CARD_LABEL))
             .perform(click())
@@ -880,8 +880,8 @@ class CardPaymentTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", CHALLENGE_NO_PREFERENCE)
-                putString("scaExemption", SCA_LOW_VALUE)
+                putString("challenge_request_indicator", CHALLENGE_NO_PREFERENCE)
+                putString("sca_exemption", SCA_LOW_VALUE)
             }.commit()
         onView(withText(PREAUTH_WITH_CARD_LABEL))
             .perform(click())

--- a/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/RavelinIntegrationTest.kt
+++ b/judokit-android-examples/src/androidTest/java/com/judokit/android/examples/test/card/RavelinIntegrationTest.kt
@@ -68,7 +68,7 @@ class RavelinIntegrationTest {
                 putString("amount", "0.15")
                 putString("currency", "GBP")
                 putBoolean("should_ask`_for_csc", false)
-                putBoolean("is_recommendation_feature_enabled", true)
+                putBoolean("is_recommendation_enabled", true)
                 putString("rsa_key", BuildConfig.RSA_KEY)
                 putStringSet("payment_methods", setOf("CARD"))
                 putBoolean("is_address_enabled", false)
@@ -233,8 +233,8 @@ class RavelinIntegrationTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", "DON_T_SET")
-                putString("scaExemption", "DON_T_SET")
+                putString("challenge_request_indicator", "DON_T_SET")
+                putString("sca_exemption", "DON_T_SET")
             }.commit()
 
         updateRecommendationUrlWith("71")
@@ -265,9 +265,9 @@ class RavelinIntegrationTest {
         sharedPrefs
             .edit()
             .apply {
-                putString("challengeRequestIndicator", "CHALLENGE_AS_MANDATE")
-                putString("scaExemption", "TRANSACTION_RISK_ANALYSIS")
-                putBoolean("halt_transaction_in_case_of_any_error_enabled", false)
+                putString("challenge_request_indicator", "CHALLENGE_AS_MANDATE")
+                putString("sca_exemption", "TRANSACTION_RISK_ANALYSIS")
+                putBoolean("is_recommendation_halt_transaction_enabled", false)
             }.commit()
 
         onView(withText(PAY_WITH_CARD_LABEL))
@@ -319,7 +319,7 @@ class RavelinIntegrationTest {
         sharedPrefs
             .edit()
             .apply {
-                putBoolean("halt_transaction_in_case_of_any_error_enabled", true)
+                putBoolean("is_recommendation_halt_transaction_enabled", true)
             }.commit()
 
         updateRecommendationUrlWith("5")

--- a/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/DemoFeatureListViewModel.kt
+++ b/judokit-android-examples/src/main/java/com/judokit/android/examples/feature/DemoFeatureListViewModel.kt
@@ -212,13 +212,13 @@ class DemoFeatureListViewModel(
         val initialRecurringPayment = prefs.getBoolean("is_initial_recurring_payment", false)
         val delayedAuthorisation = prefs.getBoolean("is_delayed_authorisation_on", false)
         val allowIncrement = prefs.getBoolean("is_allow_increment_on", false)
-        val mobileNumber = prefs.getString("mobile_number", null)
-        val phoneCountryCode = prefs.getString("phone_country_code", null)
-        val emailAddress = prefs.getString("email_address", null)
-        val challengeRequestIndicator = parseEnumPref<ChallengeRequestIndicator>("challengeRequestIndicator")
-        val scaExemption = parseEnumPref<ScaExemption>("scaExemption")
-        val threeDSTwoMaxTimeout = prefs.getString("threeDSTwoMaxTimeout", null)?.toInt()
-        val messageVersion = prefs.getString("threeDSTwoMessageVersion", null)
+        val mobileNumber = prefs.getString("address_mobile_number", null)
+        val phoneCountryCode = prefs.getString("address_phone_country_code", null)
+        val emailAddress = prefs.getString("address_email_address", null)
+        val challengeRequestIndicator = parseEnumPref<ChallengeRequestIndicator>("challenge_request_indicator")
+        val scaExemption = parseEnumPref<ScaExemption>("sca_exemption")
+        val threeDSTwoMaxTimeout = prefs.getString("three_ds_two_max_timeout", null)?.toInt()
+        val messageVersion = prefs.getString("three_ds_two_message_version", null)
         val isDisableNetworkTokenisationOn = prefs.getBoolean("is_disable_network_tokenisation_on", false)
 
         val extras =
@@ -369,13 +369,13 @@ class DemoFeatureListViewModel(
 
     private val recommendationConfiguration: RecommendationConfiguration?
         get() {
-            if (!prefs.getBoolean("is_recommendation_feature_enabled", false)) return null
+            if (!prefs.getBoolean("is_recommendation_enabled", false)) return null
             return RecommendationConfiguration
                 .Builder()
                 .setRsaPublicKey(prefs.getString("rsa_key", null))
                 .setUrl(prefs.getString("recommendation_url", null))
                 .setTimeout(prefs.getString("recommendation_timeout", null)?.toInt())
-                .setShouldHaltTransactionInCaseOfAnyError(prefs.getBoolean("halt_transaction_in_case_of_any_error_enabled", false))
+                .setShouldHaltTransactionInCaseOfAnyError(prefs.getBoolean("is_recommendation_halt_transaction_enabled", false))
                 .build()
         }
 
@@ -386,7 +386,7 @@ class DemoFeatureListViewModel(
                 UiConfiguration
                     .Builder()
                     .setAvsEnabled(prefs.getBoolean("is_avs_enabled", false))
-                    .setShouldPaymentMethodsDisplayAmount(prefs.getBoolean("should_display_amount", true))
+                    .setShouldPaymentMethodsDisplayAmount(prefs.getBoolean("should_payment_methods_display_amount", true))
                     .setShouldPaymentMethodsVerifySecurityCode(prefs.getBoolean("should_payment_methods_verify_security_code", true))
                     .setShouldAskForCSC(prefs.getBoolean("should_ask_for_csc", false))
                     .setShouldAskForCardholderName(prefs.getBoolean("should_ask_for_cardholder_name", false))

--- a/judokit-android-examples/src/main/java/com/judokit/android/examples/settings/SettingsImporter.kt
+++ b/judokit-android-examples/src/main/java/com/judokit/android/examples/settings/SettingsImporter.kt
@@ -25,22 +25,22 @@ object SettingsImporter {
                 ),
             "recommendation" to
                 listOf(
-                    "is_recommendation_feature_enabled",
+                    "is_recommendation_enabled",
                     "recommendation_url",
                     "rsa_key",
                     "recommendation_timeout",
-                    "halt_transaction_in_case_of_any_error_enabled",
+                    "is_recommendation_halt_transaction_enabled",
                 ),
             "three_ds" to
                 listOf(
                     "should_ask_for_billing_information",
-                    "challengeRequestIndicator",
-                    "scaExemption",
-                    "threeDSTwoMaxTimeout",
+                    "challenge_request_indicator",
+                    "sca_exemption",
+                    "three_ds_two_max_timeout",
                     "connect_timeout",
                     "read_timeout",
                     "write_timeout",
-                    "threeDSTwoMessageVersion",
+                    "three_ds_two_message_version",
                 ),
             "three_ds_ui_customisation" to
                 listOf(
@@ -105,9 +105,9 @@ object SettingsImporter {
                     "address_billing_country",
                     "address_country_code",
                     "address_administrative_division",
-                    "phone_country_code",
-                    "mobile_number",
-                    "email_address",
+                    "address_phone_country_code",
+                    "address_mobile_number",
+                    "address_email_address",
                 ),
             "primary_account" to
                 listOf(
@@ -139,7 +139,7 @@ object SettingsImporter {
                 listOf(
                     "is_avs_enabled",
                     "should_payment_methods_verify_security_code",
-                    "should_display_amount",
+                    "should_payment_methods_display_amount",
                     "should_payment_button_display_amount",
                     "is_initial_recurring_payment",
                     "is_delayed_authorisation_on",

--- a/judokit-android-examples/src/main/res/xml/root_preferences.xml
+++ b/judokit-android-examples/src/main/res/xml/root_preferences.xml
@@ -78,26 +78,26 @@
         <SwitchPreference
             app:defaultValue="false"
             app:iconSpaceReserved="false"
-            app:key="is_recommendation_feature_enabled"
+            app:key="is_recommendation_enabled"
             app:summary="@string/is_recommendation_feature_enabled_summary"
             app:title="@string/is_recommendation_feature_encryption_enabled_title" />
 
         <EditTextPreference
-            app:dependency="is_recommendation_feature_enabled"
+            app:dependency="is_recommendation_enabled"
             app:iconSpaceReserved="false"
             app:key="recommendation_url"
             app:summary="@string/reccomendation_url_key_summary"
             app:title="@string/reccomendation_url_title" />
 
         <EditTextPreference
-            app:dependency="is_recommendation_feature_enabled"
+            app:dependency="is_recommendation_enabled"
             app:iconSpaceReserved="false"
             app:key="rsa_key"
             app:summary="@string/rsa_key_summary"
             app:title="@string/rsa_key_title" />
 
         <EditTextPreference
-            app:dependency="is_recommendation_feature_enabled"
+            app:dependency="is_recommendation_enabled"
             app:defaultValue="30"
             app:iconSpaceReserved="false"
             app:key="recommendation_timeout"
@@ -105,10 +105,10 @@
             app:title="@string/recommendation_timeout_title" />
 
         <SwitchPreference
-            app:dependency="is_recommendation_feature_enabled"
+            app:dependency="is_recommendation_enabled"
             app:defaultValue="false"
             app:iconSpaceReserved="false"
-            app:key="halt_transaction_in_case_of_any_error_enabled"
+            app:key="is_recommendation_halt_transaction_enabled"
             app:summary="@string/recommendation_halt_transaction_in_case_of_any_error_summary"
             app:title="@string/recommendation_halt_transaction_in_case_of_any_error_title" />
 
@@ -130,7 +130,7 @@
             app:entries="@array/three_ds_two_challenge_request_indicator_entries"
             app:entryValues="@array/three_ds_two_challenge_request_indicator_values"
             app:iconSpaceReserved="false"
-            app:key="challengeRequestIndicator"
+            app:key="challenge_request_indicator"
             app:summary="@string/challenge_request_indicator_summary"
             app:title="@string/challenge_request_indicator_title"
             app:useSimpleSummaryProvider="true" />
@@ -140,7 +140,7 @@
             app:entries="@array/three_ds_two_sca_exemption_entries"
             app:entryValues="@array/three_ds_two_sca_exemption_values"
             app:iconSpaceReserved="false"
-            app:key="scaExemption"
+            app:key="sca_exemption"
             app:summary="@string/sca_exemption_summary"
             app:title="@string/sca_exemption_title"
             app:useSimpleSummaryProvider="true" />
@@ -148,7 +148,7 @@
         <EditTextPreference
             app:defaultValue="30"
             app:iconSpaceReserved="false"
-            app:key="threeDSTwoMaxTimeout"
+            app:key="three_ds_two_max_timeout"
             app:summary="@string/three_ds2_max_timeout_summary"
             app:title="@string/three_ds2_max_timeout_title"
             app:useSimpleSummaryProvider="true" />
@@ -175,7 +175,7 @@
         <EditTextPreference
             app:defaultValue=""
             app:iconSpaceReserved="false"
-            app:key="threeDSTwoMessageVersion"
+            app:key="three_ds_two_message_version"
             app:summary="@string/three_ds2_protocol_message_version_summary"
             app:title="@string/three_ds2_protocol_message_version_title" />
 
@@ -292,7 +292,7 @@
             app:defaultValue="44"
             app:dependency="is_address_enabled"
             app:iconSpaceReserved="false"
-            app:key="phone_country_code"
+            app:key="address_phone_country_code"
             app:summary="Your phone country code"
             app:title="Phone country code"
             app:useSimpleSummaryProvider="true" />
@@ -301,7 +301,7 @@
             app:defaultValue="0799999999"
             app:dependency="is_address_enabled"
             app:iconSpaceReserved="false"
-            app:key="mobile_number"
+            app:key="address_mobile_number"
             app:summary="Your mobile number"
             app:title="Mobile number"
             app:useSimpleSummaryProvider="true" />
@@ -310,7 +310,7 @@
             app:defaultValue="email@address.com"
             app:dependency="is_address_enabled"
             app:iconSpaceReserved="false"
-            app:key="email_address"
+            app:key="address_email_address"
             app:summary="Your email address"
             app:title="Email address"
             app:useSimpleSummaryProvider="true" />
@@ -504,7 +504,7 @@
         <SwitchPreference
             app:defaultValue="true"
             app:iconSpaceReserved="false"
-            app:key="should_display_amount"
+            app:key="should_payment_methods_display_amount"
             app:summary="@string/should_display_amount_summary"
             app:title="@string/should_display_amount_title" />
 


### PR DESCRIPTION
1. Adjusts names of settings keys to proper camel case where necessary. Fixes naming inconsistencies between iOS and Android. Aim of these changes is to make both Android and iOS using the same json configs in Maestro tests.